### PR TITLE
docs: complete R2 official source sync

### DIFF
--- a/docs/03-国内落地/01-国内部署/02-阿里云轻量服务器部署教程.md
+++ b/docs/03-国内落地/01-国内部署/02-阿里云轻量服务器部署教程.md
@@ -214,6 +214,18 @@ hermes
 
 ---
 
+## 🧾 R2 官方同步记录
+
+- source_id: `aliyun-lightweight-server`
+- checked_at: `2026-05-02`
+- change_type: `official-source-confirmation`
+- affected_doc: `docs/03-国内落地/01-国内部署/02-阿里云轻量服务器部署教程.md`
+- 本轮结论：已确认阿里云轻量应用服务器购买/连接、Workbench/SSH、Linux 默认端口、防火墙最小授权和 22/80/443 等检查点。
+- 后续规则：涉及价格、套餐、可用模型、控制台按钮和额度限制时，仍以厂商官方页面实时显示为准，不在本文复制长期易变表格。
+- 官方来源：
+  - https://help.aliyun.com/zh/simple-application-server/getting-started/getting-started
+  - https://help.aliyun.com/zh/simple-application-server/user-guide/manage-the-firewall-of-a-server
+
 ## ➡️ 下一步
 
 完成后进入：

--- a/docs/03-国内落地/01-国内部署/03-腾讯云轻量服务器部署教程.md
+++ b/docs/03-国内落地/01-国内部署/03-腾讯云轻量服务器部署教程.md
@@ -204,6 +204,18 @@ hermes setup
 
 ---
 
+## 🧾 R2 官方同步记录
+
+- source_id: `tencent-cloud-lighthouse`
+- checked_at: `2026-05-02`
+- change_type: `official-source-confirmation`
+- affected_doc: `docs/03-国内落地/01-国内部署/03-腾讯云轻量服务器部署教程.md`
+- 本轮结论：已确认腾讯云 Lighthouse 产品定位、镜像/套餐/防火墙概念、SSH 登录与不支持端口等官方 FAQ 口径。
+- 后续规则：涉及价格、套餐、可用模型、控制台按钮和额度限制时，仍以厂商官方页面实时显示为准，不在本文复制长期易变表格。
+- 官方来源：
+  - https://cloud.tencent.com/product/lighthouse
+  - https://cloud.tencent.com/document/product/1207/44569
+
 ## ➡️ 下一步
 
 完成后进入：

--- a/docs/03-国内落地/02-国内模型/02-阿里云百炼Token plan.md
+++ b/docs/03-国内落地/02-国内模型/02-阿里云百炼Token plan.md
@@ -279,6 +279,18 @@ hermes chat -m qwen3.6-plus
 - https://help.aliyun.com/zh/model-studio/hermes-agent-token-plan
 - https://help.aliyun.com/zh/model-studio/get-api-key
 
+## 🧾 R2 官方同步记录
+
+- source_id: `aliyun-bailian`
+- checked_at: `2026-05-02`
+- change_type: `official-source-confirmation`
+- affected_doc: `docs/03-国内落地/02-国内模型/02-阿里云百炼Token plan.md`
+- 本轮结论：已确认 Token Plan 团队版 OpenAI/Anthropic 兼容端点、专属 API Key 口径，以及不要混用通用百炼 API Key / Coding Plan Key 的风险。
+- 后续规则：涉及价格、套餐、可用模型、控制台按钮和额度限制时，仍以厂商官方页面实时显示为准，不在本文复制长期易变表格。
+- 官方来源：
+  - https://help.aliyun.com/zh/model-studio/other-tools-token-plan
+  - https://help.aliyun.com/zh/model-studio/token-plan-faq
+
 ---
 
 ## 🔗 模型接入关联路径

--- a/docs/03-国内落地/02-国内模型/03-腾讯云Token Plan.md
+++ b/docs/03-国内落地/02-国内模型/03-腾讯云Token Plan.md
@@ -254,6 +254,19 @@
 - https://cloud.tencent.com/document/product/1823/130060
 - https://cloud.tencent.com/document/product/1823/130119
 
+## 🧾 R2 官方同步记录
+
+- source_id: `tencent-cloud-models`
+- checked_at: `2026-05-02`
+- change_type: `official-source-confirmation`
+- affected_doc: `docs/03-国内落地/02-国内模型/03-腾讯云Token Plan.md`
+- 本轮结论：已确认 TokenHub Token Plan 套餐定位、模型/工具入口、API Key 管理路径；页面不复制长期易变价格表，以官方套餐页为准。
+- 后续规则：涉及价格、套餐、可用模型、控制台按钮和额度限制时，仍以厂商官方页面实时显示为准，不在本文复制长期易变表格。
+- 官方来源：
+  - https://cloud.tencent.com/document/product/1823/130060
+  - https://cloud.tencent.com/document/product/1823/130119
+  - https://cloud.tencent.com/document/product/1729/111008
+
 ---
 
 ## 🔗 模型接入关联路径

--- a/docs/03-国内落地/02-国内模型/04-智谱GLM Coding Plan.md
+++ b/docs/03-国内落地/02-国内模型/04-智谱GLM Coding Plan.md
@@ -249,6 +249,18 @@ hermes model
 - https://z.ai/subscribe
 - https://docs.z.ai/
 
+## 🧾 R2 官方同步记录
+
+- source_id: `zhipu-glm`
+- checked_at: `2026-05-02`
+- change_type: `official-source-confirmation`
+- affected_doc: `docs/03-国内落地/02-国内模型/04-智谱GLM Coding Plan.md`
+- 本轮结论：已确认 GLM Coding Plan 快速开始、API Key 获取、Claude Code/通用兼容配置和 HTTP API 端点口径。
+- 后续规则：涉及价格、套餐、可用模型、控制台按钮和额度限制时，仍以厂商官方页面实时显示为准，不在本文复制长期易变表格。
+- 官方来源：
+  - https://docs.bigmodel.cn/cn/coding-plan/quick-start
+  - https://docs.bigmodel.cn/cn/guide/develop/http/introduction
+
 ---
 
 ## 🔗 模型接入关联路径

--- a/docs/03-国内落地/02-国内模型/05-MiniMax Token Plan.md
+++ b/docs/03-国内落地/02-国内模型/05-MiniMax Token Plan.md
@@ -278,6 +278,19 @@ hermes model
 - https://www.minimax.io/
 - https://www.minimax.io/platform/
 
+## 🧾 R2 官方同步记录
+
+- source_id: `minimax`
+- checked_at: `2026-05-02`
+- change_type: `official-source-confirmation`
+- affected_doc: `docs/03-国内落地/02-国内模型/05-MiniMax Token Plan.md`
+- 本轮结论：已确认 Token Plan quickstart、API Key 获取、Anthropic 推荐端点和 OpenAI-compatible 文本接口；页面保留“以官方模型/额度页为准”。
+- 后续规则：涉及价格、套餐、可用模型、控制台按钮和额度限制时，仍以厂商官方页面实时显示为准，不在本文复制长期易变表格。
+- 官方来源：
+  - https://platform.minimax.io/docs/token-plan/quickstart
+  - https://platform.minimax.io/docs/guides/quickstart-preparation
+  - https://platform.minimax.io/docs/api-reference/text-openai-api
+
 ---
 
 ## 🔗 模型接入关联路径

--- a/docs/03-国内落地/02-国内模型/06-Kimi登月计划.md
+++ b/docs/03-国内落地/02-国内模型/06-Kimi登月计划.md
@@ -286,6 +286,19 @@ hermes model
 - https://www.kimi.com/membership/pricing
 - https://platform.kimi.com/docs/overview
 
+## 🧾 R2 官方同步记录
+
+- source_id: `kimi-moonshot`
+- checked_at: `2026-05-02`
+- change_type: `official-source-confirmation`
+- affected_doc: `docs/03-国内落地/02-国内模型/06-Kimi登月计划.md`
+- 本轮结论：已确认 Kimi Code API 接入、Kimi API OpenAI SDK 示例、MOONSHOT_API_KEY 与 base_url 口径；具体模型名以后续官方文档为准。
+- 后续规则：涉及价格、套餐、可用模型、控制台按钮和额度限制时，仍以厂商官方页面实时显示为准，不在本文复制长期易变表格。
+- 官方来源：
+  - https://www.kimi.com/code/docs/
+  - https://platform.kimi.ai/docs/guide/start-using-kimi-api
+  - https://platform.kimi.ai/docs/guide/kimi-k2-quickstart
+
 ---
 
 ## 🔗 模型接入关联路径

--- a/docs/03-国内落地/02-国内模型/07-DeepSeek按量计费接口.md
+++ b/docs/03-国内落地/02-国内模型/07-DeepSeek按量计费接口.md
@@ -315,6 +315,18 @@ hermes model
 如果你想先回到上一阶段入口重新确认位置：
 - [02-国内模型总览](./01-总览.md)
 
+## 🧾 R2 官方同步记录
+
+- source_id: `deepseek`
+- checked_at: `2026-05-02`
+- change_type: `official-source-confirmation`
+- affected_doc: `docs/03-国内落地/02-国内模型/07-DeepSeek按量计费接口.md`
+- 本轮结论：已确认 DeepSeek 官方 OpenAI/Anthropic 兼容、base_url、当前模型名与旧模型名弃用提示；页面不写死密钥或账户信息。
+- 后续规则：涉及价格、套餐、可用模型、控制台按钮和额度限制时，仍以厂商官方页面实时显示为准，不在本文复制长期易变表格。
+- 官方来源：
+  - https://api-docs.deepseek.com/
+  - https://api-docs.deepseek.com/guides/anthropic_api
+
 ---
 
 ## 🔗 模型接入关联路径

--- a/docs/03-国内落地/02-国内模型/08-自定义兼容接口.md
+++ b/docs/03-国内落地/02-国内模型/08-自定义兼容接口.md
@@ -341,6 +341,20 @@ hermes model
 - https://lmstudio.ai/docs/
 - https://docs.ollama.com/openai
 
+## 🧾 R2 官方同步记录
+
+- source_id: `custom-openai-compatible-provider`
+- checked_at: `2026-05-02`
+- change_type: `official-source-confirmation`
+- affected_doc: `docs/03-国内落地/02-国内模型/08-自定义兼容接口.md`
+- 本轮结论：已确认 Hermes custom OpenAI-compatible endpoint 口径、OPENAI_API_KEY / OPENAI_BASE_URL 变量，以及本地兼容服务只在协议真实匹配时可用。
+- 后续规则：涉及价格、套餐、可用模型、控制台按钮和额度限制时，仍以厂商官方页面实时显示为准，不在本文复制长期易变表格。
+- 官方来源：
+  - https://hermes-agent.nousresearch.com/docs/reference/environment-variables
+  - https://github.com/NousResearch/hermes-agent/blob/main/website/docs/developer-guide/adding-providers.md
+  - https://docs.ollama.com/openai
+  - https://lmstudio.ai/docs/
+
 ---
 
 ## 🔗 模型接入关联路径

--- a/governance/upstream-source-registry.yaml
+++ b/governance/upstream-source-registry.yaml
@@ -89,35 +89,86 @@ sources:
     sync_rule: "The site consumes this content repository; it must not become a second content truth source."
 
 provider_sources_to_fill_in_r2:
-  note: "R2 must verify each provider page against provider-official docs before publishing material claim updates. Keep source URLs in the R2 working notes or update this registry when stable."
+  note: "R2 has confirmed provider-official sources for domestic model and deployment pages. Re-check volatile pricing/console UI before future material claim updates."
+  checked_at: "2026-05-02"
   providers:
     - id: aliyun-bailian
       area: "国内模型"
-      status: "needs_provider_official_url_confirmation"
+      status: "confirmed_provider_official_sources"
+      source_urls:
+        - "https://help.aliyun.com/zh/model-studio/other-tools-token-plan"
+        - "https://help.aliyun.com/zh/model-studio/token-plan-faq"
+      affected_docs:
+        - "docs/03-国内落地/02-国内模型/02-阿里云百炼Token plan.md"
     - id: tencent-cloud-models
       area: "国内模型"
-      status: "needs_provider_official_url_confirmation"
+      status: "confirmed_provider_official_sources"
+      source_urls:
+        - "https://cloud.tencent.com/document/product/1823/130060"
+        - "https://cloud.tencent.com/document/product/1823/130119"
+        - "https://cloud.tencent.com/document/product/1729/111008"
+      affected_docs:
+        - "docs/03-国内落地/02-国内模型/03-腾讯云Token Plan.md"
     - id: zhipu-glm
       area: "国内模型"
-      status: "needs_provider_official_url_confirmation"
+      status: "confirmed_provider_official_sources"
+      source_urls:
+        - "https://docs.bigmodel.cn/cn/coding-plan/quick-start"
+        - "https://docs.bigmodel.cn/cn/guide/develop/http/introduction"
+      affected_docs:
+        - "docs/03-国内落地/02-国内模型/04-智谱GLM Coding Plan.md"
     - id: minimax
       area: "国内模型"
-      status: "needs_provider_official_url_confirmation"
+      status: "confirmed_provider_official_sources"
+      source_urls:
+        - "https://platform.minimax.io/docs/token-plan/quickstart"
+        - "https://platform.minimax.io/docs/guides/quickstart-preparation"
+        - "https://platform.minimax.io/docs/api-reference/text-openai-api"
+      affected_docs:
+        - "docs/03-国内落地/02-国内模型/05-MiniMax Token Plan.md"
     - id: kimi-moonshot
       area: "国内模型"
-      status: "needs_provider_official_url_confirmation"
+      status: "confirmed_provider_official_sources"
+      source_urls:
+        - "https://www.kimi.com/code/docs/"
+        - "https://platform.kimi.ai/docs/guide/start-using-kimi-api"
+        - "https://platform.kimi.ai/docs/guide/kimi-k2-quickstart"
+      affected_docs:
+        - "docs/03-国内落地/02-国内模型/06-Kimi登月计划.md"
     - id: deepseek
       area: "国内模型"
-      status: "needs_provider_official_url_confirmation"
+      status: "confirmed_provider_official_sources"
+      source_urls:
+        - "https://api-docs.deepseek.com/"
+        - "https://api-docs.deepseek.com/guides/anthropic_api"
+      affected_docs:
+        - "docs/03-国内落地/02-国内模型/07-DeepSeek按量计费接口.md"
     - id: custom-openai-compatible-provider
       area: "国内模型"
-      status: "needs_hermes_and_provider_compatibility_confirmation"
+      status: "confirmed_hermes_and_provider_compatibility_sources"
+      source_urls:
+        - "https://hermes-agent.nousresearch.com/docs/reference/environment-variables"
+        - "https://github.com/NousResearch/hermes-agent/blob/main/website/docs/developer-guide/adding-providers.md"
+        - "https://docs.ollama.com/openai"
+        - "https://lmstudio.ai/docs/"
+      affected_docs:
+        - "docs/03-国内落地/02-国内模型/08-自定义兼容接口.md"
     - id: aliyun-lightweight-server
       area: "国内部署"
-      status: "needs_provider_official_url_confirmation"
+      status: "confirmed_provider_official_sources"
+      source_urls:
+        - "https://help.aliyun.com/zh/simple-application-server/getting-started/getting-started"
+        - "https://help.aliyun.com/zh/simple-application-server/user-guide/manage-the-firewall-of-a-server"
+      affected_docs:
+        - "docs/03-国内落地/01-国内部署/02-阿里云轻量服务器部署教程.md"
     - id: tencent-cloud-lighthouse
       area: "国内部署"
-      status: "needs_provider_official_url_confirmation"
+      status: "confirmed_provider_official_sources"
+      source_urls:
+        - "https://cloud.tencent.com/product/lighthouse"
+        - "https://cloud.tencent.com/document/product/1207/44569"
+      affected_docs:
+        - "docs/03-国内落地/01-国内部署/03-腾讯云轻量服务器部署教程.md"
 
 change_policy:
   record_on_doc_update:

--- a/scripts/upstream_sync.py
+++ b/scripts/upstream_sync.py
@@ -167,6 +167,19 @@ def validate(options: CheckOptions) -> dict[str, Any]:
     for key in failed_reachability:
         warnings.append(f"source reachability failed: {key}")
 
+    r2_provider_block = registry.get("provider_sources_to_fill_in_r2", {})
+    r2_providers = r2_provider_block.get("providers", []) if isinstance(r2_provider_block, dict) else []
+    r2_confirmed = sum(
+        1
+        for provider in r2_providers
+        if str(provider.get("status", "")).startswith("confirmed_") and provider.get("source_urls")
+    )
+    r2_pending = sum(
+        1
+        for provider in r2_providers
+        if str(provider.get("status", "")).startswith("needs_") or not provider.get("source_urls")
+    )
+
     payload = {
         "status": "failed" if issues else "ok",
         "checked_at": date.today().isoformat(),
@@ -178,9 +191,9 @@ def validate(options: CheckOptions) -> dict[str, Any]:
             "official_sources": official_count,
             "provider_official_sources": provider_count,
             "local_content_sources": local_count,
-            "r2_provider_placeholders": len(
-                (registry.get("provider_sources_to_fill_in_r2", {}) or {}).get("providers", [])
-            ) if isinstance(registry.get("provider_sources_to_fill_in_r2", {}), dict) else 0,
+            "r2_provider_sources_total": len(r2_providers),
+            "r2_provider_sources_confirmed": r2_confirmed,
+            "r2_provider_sources_pending": r2_pending,
         },
         "issues": issues,
         "warnings": warnings,
@@ -245,20 +258,23 @@ def render_digest(options: CheckOptions) -> str:
                 rule=str(source.get("sync_rule", "")).replace("|", "/"),
             )
         )
-    lines.extend(["", "## R2 待补官方来源", ""])
+    lines.extend(["", "## R2 官方来源确认状态", ""])
     if providers:
-        lines.extend(["| ID | Area | Status |", "|---|---|---|"])
+        lines.extend(["| ID | Area | Status | Source URLs |", "|---|---|---|---|"])
         for provider in providers:
-            lines.append(f"| `{provider.get('id', '')}` | {provider.get('area', '')} | `{provider.get('status', '')}` |")
+            source_count = len(provider.get("source_urls") or [])
+            lines.append(
+                f"| `{provider.get('id', '')}` | {provider.get('area', '')} | `{provider.get('status', '')}` | {source_count} |"
+            )
     else:
         lines.append("- none")
     lines.extend([
         "",
         "## 维护者下一步",
         "",
-        "1. R1 只建立 registry / policy / 脚本，不批量改正文事实。",
-        "2. R2 更新国内模型或部署页面前，先补厂商官方来源 URL 与 checked date。",
-        "3. 如发现本仓内容与官方来源冲突，先开 review issue，再改正文。",
+        "1. R1 已完成 registry / policy / 脚本基座。",
+        "2. R2 已把国内模型 / 部署页面的厂商官方来源写回 registry 与页面同步记录。",
+        "3. 后续如发现本仓内容与官方来源冲突，先开 review issue，再改正文。",
         "",
         "## 禁止项确认",
         "",
@@ -278,16 +294,16 @@ def render_issue_body(options: CheckOptions) -> str:
     digest = render_digest(options)
     return "\n".join([
         "## 背景",
-        "R1 已建立官方来源 registry / policy，需要进入 R2 前确认国内模型与部署页面的厂商官方来源。",
+        "R1 已建立官方来源 registry / policy；R2 已确认国内模型与部署页面的厂商官方来源，并把来源写回 registry 与页面同步记录。",
         "",
-        "## R1 dry-run digest",
+        "## R2 digest",
         "",
         digest,
         "",
         "## 建议处理",
         "",
-        "- [ ] 为 R2 国内模型页面补厂商官方来源 URL。",
-        "- [ ] 为 R2 国内部署页面补厂商官方来源 URL。",
+        "- [ ] 后续修改国内模型页面前，先复查 registry 中对应 source_urls。",
+        "- [ ] 后续修改国内部署页面前，先复查 registry 中对应 source_urls。",
         "- [ ] 对任何影响用户操作的正文改动记录 source / checked_at / affected_docs。",
         "",
         "## Dry-run 声明",

--- a/tests/test_upstream_sync.py
+++ b/tests/test_upstream_sync.py
@@ -39,7 +39,8 @@ def test_digest_renders_human_markdown_without_internal_logs():
     body = result.stdout
     assert "# 官方来源同步 Digest" in body
     assert "hermes-official-docs" in body
-    assert "R2 待补官方来源" in body
+    assert "R2 官方来源确认状态" in body
+    assert "r2_provider_sources_pending" not in body
     assert "dispatch" not in body.lower()
     assert "worker_run" not in body.lower()
 
@@ -53,7 +54,7 @@ def test_issue_dry_run_never_calls_github_and_marks_no_side_effect():
     assert payload["side_effect"] == "none"
     assert payload["title"].startswith("R1 官方来源同步")
     assert "gh issue create" not in payload["body"]
-    assert "R2 待补官方来源" in payload["body"]
+    assert "R2 官方来源确认状态" in payload["body"]
 
 
 def test_check_fails_when_registry_missing_required_official_source(tmp_path: Path):


### PR DESCRIPTION
## Summary
- confirm R2 provider official source URLs in upstream registry
- add R2 official sync records to 7 domestic model pages and 2 domestic deployment pages
- update upstream sync digest/tests from pending-source wording to confirmed-source status

## Verification
- python scripts/upstream_sync.py check --no-network
- python scripts/upstream_sync.py digest --no-network
- pytest -q